### PR TITLE
Adds "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "un-calendar",
   "main": "dist/globals/un-calendar.js",
   "ember-addon": {
-    "main": "ember-addon/index.js"
+    "main": "ember-addon/index.js",
+    "demoURL": "http://emberjs.jsbin.com/komop/2/"
   },
   "version": "0.2.3",
   "description": "A calendar component for Ember with a speedy month view",


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".
